### PR TITLE
Update README.md: add links to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Automatically derive [spray-json][spray-json] `JsonFormat`s, powered by [shapele
 
 For documentation, [read the scaladocs](src/main/scala/fommil/sjs/FamilyFormats.scala) and for examples [read the test cases](src/test/scala/fommil/sjs/FamilyFormatsSpec.scala).
 
+[spray-json]: https://github.com/spray/spray-json
+[shapeless]: https://github.com/milessabin/shapeless
+
 **Please read the documentation - especially the caveats - and examples before raising a ticket.**
 
 ## TL;DR


### PR DESCRIPTION
Note to the maintainer(s) (@fommil et al?): I'm checking if this repo is the right place to submit changes and to find out if it's maintained at all.

Are you accepting PRs at all?

I'm unsure about the consequence of switching the license to copyleft (introduced with the d3460a6684a132b6b4201af7bd11449021d61dec, the last commit atm). Does it also mean that you do not intend to update this repo at all?

I could find [1.4.0 artifact on bintray](http://jcenter.bintray.com/com/github/fommil/spray-json-shapeless_2.12/1.4.0/) but there's no repository I could find. OTOH, he corresponding `-sources.jar` file indicates minor differences - `Typeable` being implicitly injected so that type info can be traced - so basically, `1.4.0` adds no new functionality to `1.3.0`.

Anyway, prior incarnations of this project are either not maintained anymore (like [milessabin/spray-json-shapeless](https://github.com/milessabin/spray-json-shapeless)) or not there (like [fommil/spray-json-shapeless](https://github.com/fommil/spray-json-shapeless)) and this looks like the best place to submit a PR and ask the above questions.